### PR TITLE
Fix the build so that it actually works

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,11 +15,11 @@ build-A:
 
 
 flash:
-	cd crates/ui ; cargo flash --chip STM32F405RG --bin ui --no-default-features --features bsp/board-hactar12,hal/stm32f405 --target=thumbv7em-none-eabihf
+	cd crates/ui ; cargo flash --chip STM32F405RGTx --bin ui --no-default-features --connect-under-reset --features bsp/board-hactar12,hal/stm32f405 --target=thumbv7em-none-eabihf
 
 
 flash-A:
-	cd crates/ui ; cargo flash --chip STM32F405RG --bin ui --no-default-features --features bsp/board-blinkA,hal/stm32f405 --target=thumbv7em-none-eabihf
+	cd crates/ui ; cargo flash --chip STM32F405RGTx --bin ui --no-default-features --features bsp/board-blinkA,hal/stm32f405 --target=thumbv7em-none-eabihf
 
 
 build-mgmt:
@@ -27,7 +27,7 @@ build-mgmt:
 
 
 flash-mgmt:
-	cd crates/mgmt; cargo flash --chip STM32F072CB --bin mgmt --no-default-features --features hal/stm32f072 --target=thumbv6m-none-eabi --release
+	cd crates/mgmt; cargo flash --chip STM32F072CBTx --bin mgmt --no-default-features --features hal/stm32f072 --target=thumbv6m-none-eabi --release
 
 
 run-mgmt:

--- a/crates/mgmt/src/main.rs
+++ b/crates/mgmt/src/main.rs
@@ -11,7 +11,6 @@ mod stack;
 mod startup;
 
 #[no_mangle]
-#[export_name = "main"]
 #[inline(never)]
 /// Entry point for the application when the `std` feature is not enabled.
 pub extern "C" fn main() -> ! {

--- a/crates/ui/src/main.rs
+++ b/crates/ui/src/main.rs
@@ -32,7 +32,6 @@ pub use msg::Msg;
 
 #[cfg(not(feature = "std"))]
 #[no_mangle]
-#[export_name = "main"]
 #[inline(never)]
 /// Entry point for the application when the `std` feature is not enabled.
 pub extern "C" fn main() -> ! {


### PR DESCRIPTION
* `export-name` isn't needed when the function already has the name you need
* Chip names need to be more specific